### PR TITLE
[LIDO-1521] Fix join column parsing bug

### DIFF
--- a/grammar/lexing.js
+++ b/grammar/lexing.js
@@ -80,7 +80,7 @@ const TableName = createToken({
 
 const ColumnName = createToken({
     name: 'ColumnName',
-    pattern: /[\[]?[@]?[\[+]?[%A-Za-z_.\d\s\u007F-\uFFFF]{0,}\]+/
+    pattern: /[\[]?[@]?[\[+]?[%:A-Za-z_.\d\s\u007F-\uFFFF]{0,}\]+/
 })
 
 const SpecialItem = createToken({

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lido-app/fast-formula-parser",
-  "version": "1.0.25",
+  "version": "1.0.26-canary.0",
   "description": "fast excel formula parser",
   "repository": "https://github.com/lido-app/fast-formula-parser",
   "main": "index.js",

--- a/package.json
+++ b/package.json
@@ -1,12 +1,12 @@
 {
   "name": "@lido-app/fast-formula-parser",
-  "version": "1.0.26-canary.0",
+  "version": "1.0.26-canary.1",
   "description": "fast excel formula parser",
   "repository": "https://github.com/lido-app/fast-formula-parser",
   "main": "index.js",
   "publishConfig": {
     "access": "public",
-    "registry": "https://npm.pkg.github.com/"
+    "registry": "https://npm.pkg.github.com/Lido-App"
   },
   "scripts": {
     "test": "mocha -s 0",

--- a/test/joins/joins.js
+++ b/test/joins/joins.js
@@ -1,0 +1,42 @@
+
+const { FormulaParser } = require('../../grammar/hooks');
+const { expect } = require('chai');
+
+
+const parser = new FormulaParser({
+  onCell: (ref) => {
+    return 1
+  },
+  onRange: () => {
+    return [[1, 2]]
+  },
+  onStructuredReference: (tableName, columnName, thisRow, specialItem, sheet, position) => {
+    if (thisRow || specialItem) {
+      // Single cell
+      return { row: 2, col: 2 }
+    } else {
+      // Full column
+      return {
+        sheet: 'Sheet 1',
+        from: {
+          row: 1,
+          col: 1
+        },
+        to: {
+          row: 10,
+          col: 1
+        }
+      }
+    }
+  }
+});
+
+const position = { row: 1, col: 1, sheet: 'Sheet1' };
+
+describe('Joins', function () {
+  it('should parse join columns', async () => {
+    let actual = await parser.parseAsync('Table Name[Join: Column Name]', position, true);
+    expect(actual).to.deep.eq([[1, 2]]);
+  });
+
+});

--- a/test/test.js
+++ b/test/test.js
@@ -1,6 +1,6 @@
 const assert = require('assert');
 const expect = require('chai').expect;
-const {FormulaParser} = require('../grammar/hooks');
+const { FormulaParser } = require('../grammar/hooks');
 const parser = new FormulaParser(undefined, true);
 
 const fs = require('fs');
@@ -36,7 +36,7 @@ describe('Parsing Formulas 1', function () {
         formulas.forEach((formula, index) => {
             // console.log('testing #', index, formula);
             try {
-                parser.parse(formula, {row: 2, col: 2});
+                parser.parse(formula, { row: 2, col: 2 });
                 success++;
             } catch (e) {
                 failures.push(formula);
@@ -66,11 +66,11 @@ describe('Parsing Formulas 2', () => {
         });
     });
 
-    it ('skip', () => '');
+    it('skip', () => '');
 
-    it('custom formulas parse rate should be 100%',  function(done) {
+    it('custom formulas parse rate should be 100%', function (done) {
         this.timeout(20000);
-        formulas.forEach((formula, index)  => {
+        formulas.forEach((formula, index) => {
             // console.log('testing #', index, formula);
             try {
                 parser.parse(formula);
@@ -93,7 +93,7 @@ describe('Parsing Formulas 2', () => {
 });
 
 describe('Get supported formulas', () => {
-    const functionsNames =  parser.supportedFunctions();
+    const functionsNames = parser.supportedFunctions();
     expect(functionsNames.length).to.greaterThan(275);
     console.log(`Support ${functionsNames.length} functions:\n${functionsNames.join(', ')}`);
     expect(functionsNames.includes('IFNA')).to.eq(true);
@@ -106,4 +106,5 @@ require('./grammar/errors');
 require('./grammar/collection');
 require('./grammar/depParser');
 require('./formulas');
-require('./structuredreferences/structuredreferences')
+require('./structuredreferences/structuredreferences');
+require('./joins/joins');


### PR DESCRIPTION
Add colon to column name parsing regex to allow parsing of cells formatted `Table Name[Join: Column Name]`, or any manually named column including a colon.

Note: Some on-save formatting changes were applied and committed, not sure how to suppress.